### PR TITLE
feat(ocr): add OAuth2 client credentials authentication to LiteLLM

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -85,8 +85,10 @@ export * from './shared/types';
 // The factory will handle environment-specific provider selection
 
 export type {
+  LiteLLMAuthType,
   LiteLLMOutputMode,
   LiteLLMProviderConfig,
+  OAuth2Config,
 } from './node/litellm';
 // Export LiteLLM provider for direct instantiation
 export { LiteLLMProvider } from './node/litellm';


### PR DESCRIPTION
## Summary

Add OAuth2 client credentials flow authentication support to the LiteLLM OCR provider, enabling integration with Keycloak-protected LiteLLM servers.

### Changes
- Add `authType` config option (`'api_key'` | `'oauth2'`)
- Add `OAuth2Config` interface with `tokenUrl`, `clientId`, `clientSecret`, `scopes`
- Add environment variables for OAuth2 configuration:
  - `HAVE_OCR_LITELLM_AUTH_TYPE`
  - `HAVE_OCR_LITELLM_OAUTH2_TOKEN_URL`
  - `HAVE_OCR_LITELLM_OAUTH2_CLIENT_ID`
  - `HAVE_OCR_LITELLM_OAUTH2_CLIENT_SECRET`
  - `HAVE_OCR_LITELLM_OAUTH2_SCOPES`
- Implement token caching with 60-second expiry buffer
- Export `OAuth2Config` and `LiteLLMAuthType` types from package index

### Usage

```typescript
// API key authentication (existing behavior)
const provider = new LiteLLMProvider({
  baseUrl: 'http://localhost:4000/v1',
  apiKey: 'your-api-key',
  model: 'deepseek-ocr'
});

// OAuth2 client credentials authentication (new)
const provider = new LiteLLMProvider({
  baseUrl: 'https://litellm.example.com/v1',
  authType: 'oauth2',
  oauth2: {
    tokenUrl: 'https://auth.example.com/realms/myrealm/protocol/openid-connect/token',
    clientId: 'my-client',
    clientSecret: 'my-secret',
    scopes: ['optional', 'scopes']
  },
  model: 'deepseek-ocr'
});
```

Or via environment variables:
```bash
export HAVE_OCR_LITELLM_AUTH_TYPE=oauth2
export HAVE_OCR_LITELLM_OAUTH2_TOKEN_URL=https://auth.example.com/realms/myrealm/protocol/openid-connect/token
export HAVE_OCR_LITELLM_OAUTH2_CLIENT_ID=my-client
export HAVE_OCR_LITELLM_OAUTH2_CLIENT_SECRET=my-secret
```

## Test plan
- [x] Unit tests for OAuth2 configuration loading
- [x] Unit tests for OAuth2 token fetching
- [x] Unit tests for token caching behavior
- [x] Unit tests for token fetch failure handling
- [x] Unit tests for scope inclusion in token request
- [x] Unit tests for cached token cleanup
- [x] All 63 tests passing
- [x] Build successful
- [x] TypeScript compilation clean