### PR TITLE
fix: auto-publish on dependency updates

### DIFF
--- a/scripts/auto-changeset.ts
+++ b/scripts/auto-changeset.ts
@@ -7,8 +7,8 @@
  *
  * Version bump rules for 0.x.x releases:
  * - Breaking changes (feat!, BREAKING CHANGE) → minor bump (0.x.0)
- * - Features, fixes, perf → patch bump (0.0.x)
- * - Other commit types (chore, docs, etc.) → no bump
+ * - Features, fixes, perf, dep updates → patch bump (0.0.x)
+ * - Other commit types (docs, style, etc.) → no bump
  */
 
 import { execSync } from 'node:child_process';
@@ -102,8 +102,11 @@ function determineVersionBump(
 
   const hasFeature = commits.some((c) => c.type === 'feat');
   const hasFix = commits.some((c) => ['fix', 'perf'].includes(c.type));
+  const hasDeps = commits.some(
+    (c) => c.type === 'chore' && c.scope === 'deps',
+  );
 
-  if (hasFeature || hasFix) return 'patch';
+  if (hasFeature || hasFix || hasDeps) return 'patch';
 
   return null; // No releaseable commits
 }
@@ -115,6 +118,9 @@ function generateChangesetContent(
   const features = commits.filter((c) => c.type === 'feat');
   const fixes = commits.filter((c) => c.type === 'fix');
   const breaking = commits.filter((c) => c.breaking);
+  const deps = commits.filter(
+    (c) => c.type === 'chore' && c.scope === 'deps',
+  );
 
   let content = `---\n`;
   content += `"${PACKAGE_NAME}": ${bump}\n`;
@@ -140,6 +146,14 @@ function generateChangesetContent(
     content += `### Bug Fixes\n\n`;
     fixes.forEach((c) => {
       content += `- ${c.message}${c.scope ? ` (${c.scope})` : ''}\n`;
+    });
+    content += `\n`;
+  }
+
+  if (deps.length > 0) {
+    content += `### Dependencies\n\n`;
+    deps.forEach((c) => {
+      content += `- ${c.message}\n`;
     });
   }
 


### PR DESCRIPTION
## Summary
- Treats `chore(deps)` commits as patch bumps in auto-changeset script
- Renovate dependency updates merged to main will now trigger version bumps and publish new versions

## Why
The auto-changeset script only generated changesets for `feat`, `fix`, and `perf` commits. Renovate's `chore(deps)` commits were silently ignored, so dependency updates never published new package versions. This left published versions stuck at old SDK deps (e.g., utils@0.60.9) even though main had updated to ^0.68.0.

## Test plan
- [ ] Merge and verify publish workflow runs `changeset:auto` with a version bump