### PR TITLE
feat(ocr): add bitsPerComponent to OCRImage

### DIFF
--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -75,10 +75,15 @@ export interface OCRImage {
   channels?: number;
   /**
    * Bits per channel sample. Common values: 1, 8, 16.
-   * Required for unambiguous decoding of raw pixel buffers, where
-   * `bytes.length === width * height * channels * (bitsPerComponent / 8)`.
-   * Without this, a 1-channel × 16-bit buffer is indistinguishable from
-   * a 2-channel × 8-bit buffer of the same pixel count.
+   *
+   * Required for unambiguous decoding of raw pixel buffers. Without it, a
+   * 1-channel × 16-bit buffer is indistinguishable from a 2-channel × 8-bit
+   * buffer of the same byte length.
+   *
+   * Expected buffer size depends on whether samples are byte-aligned:
+   * - Byte-aligned (8, 16, 24, …): `bytes.length === width * height * channels * (bitsPerComponent / 8)`
+   * - Bit-packed (1, 2, 4): `bytes.length === Math.ceil(width * height * channels * bitsPerComponent / 8)`
+   *   (PDF `/BitsPerComponent` 1/2/4 streams are typically packed this way.)
    */
   bitsPerComponent?: number;
   /** Image format/type */

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -73,6 +73,14 @@ export interface OCRImage {
   height?: number;
   /** Number of color channels */
   channels?: number;
+  /**
+   * Bits per channel sample. Common values: 1, 8, 16.
+   * Required for unambiguous decoding of raw pixel buffers, where
+   * `bytes.length === width * height * channels * (bitsPerComponent / 8)`.
+   * Without this, a 1-channel × 16-bit buffer is indistinguishable from
+   * a 2-channel × 8-bit buffer of the same pixel count.
+   */
+  bitsPerComponent?: number;
   /** Image format/type */
   format?: string;
   /** Optional metadata for tracking */


### PR DESCRIPTION
## Summary
- Adds optional `bitsPerComponent?: number` to the `OCRImage` interface so consumers (notably `@happyvertical/pdf` `extractImages`) can populate it directly from the PDF stream's `/BitsPerComponent` and decode raw pixel buffers unambiguously.
- Without this, a 1-channel × 16-bit buffer is indistinguishable from a 2-channel × 8-bit buffer of the same byte length, forcing downstream heuristics like the one in [anytown.ai PR #270](https://github.com/anytown/anytown.ai/pull/270).

## Test plan
- [x] `pnpm typecheck` passes
- [ ] Verify downstream `@happyvertical/pdf` can populate the new field once released
- [ ] Confirm praeco's `inferRawImageChannels` heuristic can be removed once both fixes land

Closes #75