### PR TITLE
fix(ocr): fall back after empty auto results

### DIFF
--- a/.changeset/auto-empty-result-fallback.md
+++ b/.changeset/auto-empty-result-fallback.md
@@ -1,0 +1,5 @@
+---
+"@happyvertical/ocr": patch
+---
+
+Continue through the automatic provider chain when the first available OCR provider returns an empty result.

--- a/docs/api/classes/OCRFactory.md
+++ b/docs/api/classes/OCRFactory.md
@@ -158,7 +158,7 @@ if (provider) {
 
 > **performOCR**(`images`, `options?`): `Promise`\<[`OCRResult`](../interfaces/OCRResult.md)\>
 
-Defined in: [src/shared/factory.ts:422](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L422)
+Defined in: [src/shared/factory.ts:423](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L423)
 
 Perform OCR processing on one or more images.
 
@@ -245,7 +245,7 @@ try {
 
 > **getProvidersInfo**(): `Promise`\<[`OCRProviderInfo`](../interfaces/OCRProviderInfo.md)[]\>
 
-Defined in: [src/shared/factory.ts:536](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L536)
+Defined in: [src/shared/factory.ts:519](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L519)
 
 Get detailed information about all OCR providers.
 
@@ -280,7 +280,7 @@ providers.forEach(provider => {
 
 > **isOCRAvailable**(): `Promise`\<`boolean`\>
 
-Defined in: [src/shared/factory.ts:588](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L588)
+Defined in: [src/shared/factory.ts:571](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L571)
 
 Check if OCR functionality is available in the current environment.
 
@@ -309,7 +309,7 @@ if (await factory.isOCRAvailable()) {
 
 > **getSupportedLanguages**(): `Promise`\<`string`[]\>
 
-Defined in: [src/shared/factory.ts:613](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L613)
+Defined in: [src/shared/factory.ts:596](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L596)
 
 Get array of supported language codes from the best available provider.
 
@@ -341,7 +341,7 @@ const result = await factory.performOCR(images, {
 
 > **cleanup**(): `Promise`\<`void`\>
 
-Defined in: [src/shared/factory.ts:650](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L650)
+Defined in: [src/shared/factory.ts:633](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L633)
 
 Clean up all OCR providers and release their resources.
 
@@ -382,7 +382,7 @@ process.on('SIGINT', async () => {
 
 > **addProvider**(`name`, `provider`): `void`
 
-Defined in: [src/shared/factory.ts:688](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L688)
+Defined in: [src/shared/factory.ts:671](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L671)
 
 Add a custom OCR provider to the factory.
 
@@ -429,7 +429,7 @@ const customFactory = new OCRFactory({ provider: 'custom' });
 
 > **removeProvider**(`name`): `Promise`\<`void`\>
 
-Defined in: [src/shared/factory.ts:706](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L706)
+Defined in: [src/shared/factory.ts:689](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L689)
 
 Remove an OCR provider from the factory.
 
@@ -461,7 +461,7 @@ await factory.removeProvider('custom');
 
 > **getAvailableProviderNames**(): `string`[]
 
-Defined in: [src/shared/factory.ts:731](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L731)
+Defined in: [src/shared/factory.ts:714](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L714)
 
 Get array of provider names that have been loaded in the current environment.
 
@@ -490,7 +490,7 @@ console.log('Loaded providers:', providerNames);
 
 > **getEnvironment**(): [`OCREnvironment`](../type-aliases/OCREnvironment.md)
 
-Defined in: [src/shared/factory.ts:750](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L750)
+Defined in: [src/shared/factory.ts:733](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L733)
 
 Get the detected runtime environment.
 

--- a/docs/api/functions/getAvailableProviders.md
+++ b/docs/api/functions/getAvailableProviders.md
@@ -8,7 +8,7 @@
 
 > **getAvailableProviders**(): `Promise`\<`string`[]\>
 
-Defined in: [src/shared/factory.ts:880](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L880)
+Defined in: [src/shared/factory.ts:863](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L863)
 
 Get list of OCR provider names available in the current environment.
 

--- a/docs/api/functions/getOCR.md
+++ b/docs/api/functions/getOCR.md
@@ -8,7 +8,7 @@
 
 > **getOCR**(`options?`): [`OCRFactory`](../classes/OCRFactory.md)
 
-Defined in: [src/shared/factory.ts:816](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L816)
+Defined in: [src/shared/factory.ts:799](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L799)
 
 Get or create an OCR factory instance with automatic provider selection.
 

--- a/docs/api/functions/getProviderInfo.md
+++ b/docs/api/functions/getProviderInfo.md
@@ -8,7 +8,7 @@
 
 > **getProviderInfo**(`providerName`): `Promise`\<[`OCRProviderInfo`](../interfaces/OCRProviderInfo.md) \| `null`\>
 
-Defined in: [src/shared/factory.ts:954](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L954)
+Defined in: [src/shared/factory.ts:937](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L937)
 
 Get detailed information about a specific OCR provider.
 

--- a/docs/api/functions/isProviderAvailable.md
+++ b/docs/api/functions/isProviderAvailable.md
@@ -8,7 +8,7 @@
 
 > **isProviderAvailable**(`providerName`): `Promise`\<`boolean`\>
 
-Defined in: [src/shared/factory.ts:908](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L908)
+Defined in: [src/shared/factory.ts:891](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L891)
 
 Check if a specific OCR provider is available and ready to use.
 

--- a/docs/api/functions/resetOCRFactory.md
+++ b/docs/api/functions/resetOCRFactory.md
@@ -8,7 +8,7 @@
 
 > **resetOCRFactory**(): `void`
 
-Defined in: [src/shared/factory.ts:850](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L850)
+Defined in: [src/shared/factory.ts:833](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L833)
 
 Reset the global OCR factory instance.
 

--- a/src/node/onnx-gutenye.ts
+++ b/src/node/onnx-gutenye.ts
@@ -304,7 +304,13 @@ export class ONNXGutenyeProvider implements OCRProvider {
         let height: number;
 
         // Handle different image input formats
-        if (image.data instanceof Buffer && image.width && image.height) {
+        if (
+          image.data instanceof Buffer &&
+          image.width &&
+          image.height &&
+          image.channels === 3 &&
+          image.data.byteLength === image.width * image.height * image.channels
+        ) {
           // Already RGB data with dimensions
           console.log(`Processing RGB data ${image.width}x${image.height}`);
           rgbData = image.data;

--- a/src/node/providers.spec.ts
+++ b/src/node/providers.spec.ts
@@ -1,4 +1,5 @@
 import jpeg from 'jpeg-js';
+import { PNG } from 'pngjs';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { ONNXGutenyeProvider } from './onnx-gutenye';
 import { TesseractProvider } from './tesseract';
@@ -212,6 +213,24 @@ describe('ONNXGutenyeProvider', () => {
 
     expect(result.text).toBe('JPEG text');
     expect(result.detections?.[0].boundingBox).toBeUndefined();
+  });
+
+  test('decodes encoded PNG buffers even when dimensions are present', async () => {
+    const png = new PNG({ width: 1, height: 1 });
+    png.data.set(Buffer.from([255, 0, 0, 255]));
+    const encoded = PNG.sync.write(png);
+    const detect = vi.fn().mockResolvedValue([{ text: 'PNG text', mean: 0.9 }]);
+    const provider = new ONNXGutenyeProvider();
+    const decodeSpy = vi.spyOn(provider as any, 'decodeImageToRGB');
+    (provider as any).initialized = true;
+    (provider as any).ocrInstance = { detect };
+
+    const result = await provider.performOCR([
+      { data: Buffer.from(encoded), width: 1, height: 1 },
+    ]);
+
+    expect(result.text).toBe('PNG text');
+    expect(decodeSpy).toHaveBeenCalledOnce();
   });
 
   test('skips unsupported and failed image inputs without throwing', async () => {

--- a/src/shared/factory.spec.ts
+++ b/src/shared/factory.spec.ts
@@ -309,6 +309,40 @@ describe('OCRFactory environment variable configuration', () => {
     expect(fallback.performOCR).toHaveBeenCalledTimes(1);
   });
 
+  test('should continue through auto providers when the best result is empty', async () => {
+    const onnx = createMockProvider({
+      name: 'onnx',
+      performOCR: vi.fn().mockResolvedValue({
+        text: '',
+        confidence: 0,
+        detections: [],
+      }),
+    });
+    const tesseract = createMockProvider({
+      name: 'tesseract',
+      performOCR: vi.fn().mockResolvedValue({
+        text: 'tesseract text',
+        confidence: 82,
+        detections: [],
+      }),
+    });
+    const factory = new OCRFactory({
+      provider: 'auto',
+      defaultOptions: { language: 'eng' },
+    });
+    (factory as any).initialized = true;
+    factory.addProvider('onnx', onnx);
+    factory.addProvider('tesseract', tesseract);
+
+    const result = await factory.performOCR([{ data: Buffer.alloc(128) }]);
+
+    expect(result.text).toBe('tesseract text');
+    expect(result.metadata?.provider).toBe('tesseract');
+    expect(result.metadata?.fallbackFrom).toBe('onnx');
+    expect(onnx.performOCR).toHaveBeenCalledTimes(1);
+    expect(tesseract.performOCR).toHaveBeenCalledTimes(1);
+  });
+
   test('should ignore unavailable or failing fallback providers', async () => {
     const primary = createMockProvider({
       name: 'primary',

--- a/src/shared/factory.ts
+++ b/src/shared/factory.ts
@@ -279,63 +279,9 @@ export class OCRFactory {
    * ```
    */
   async getBestProvider(): Promise<OCRProvider | null> {
-    await this.initializeProviders();
-
-    // If a specific provider is requested, try to use it
-    if (this.primaryProvider !== 'auto') {
-      const provider = this.providers.get(this.primaryProvider);
-      if (provider) {
-        const deps = await provider.checkDependencies();
-        if (deps.available) {
-          return provider;
-        }
-        console.warn(
-          `Primary OCR provider '${this.primaryProvider}' not available:`,
-          deps.error,
-        );
-      }
-    }
-
-    // Auto-select or fall back to the best available provider
-    const providerPriority =
-      this.primaryProvider === 'auto'
-        ? this.getDefaultProviderPriority()
-        : [this.primaryProvider, ...this.fallbackProviders];
-
-    // Check all providers in parallel for faster detection
-    const providerChecks = providerPriority.map(async (providerName) => {
-      const provider = this.providers.get(providerName);
-      if (!provider)
-        return { name: providerName, available: false, provider: null };
-
-      try {
-        const deps = await provider.checkDependencies();
-        return {
-          name: providerName,
-          available: deps.available,
-          provider: deps.available ? provider : null,
-          error: deps.error,
-        };
-      } catch (error) {
-        console.debug(`OCR provider '${providerName}' check failed:`, error);
-        return { name: providerName, available: false, provider: null };
-      }
-    });
-
-    const results = await Promise.all(providerChecks);
-
-    // Return first available provider in priority order
-    for (const providerName of providerPriority) {
-      const result = results.find((r) => r.name === providerName);
-      if (result?.available && result.provider) {
-        return result.provider;
-      }
-      if (result && !result.available && result.error) {
-        console.debug(
-          `OCR provider '${providerName}' not available:`,
-          result.error,
-        );
-      }
+    const providers = await this.getAvailableProviderChain();
+    if (providers.length > 0) {
+      return providers[0];
     }
 
     console.warn(
@@ -363,6 +309,61 @@ export class OCRFactory {
       return ['tesseract', 'web-ocr'];
     }
     return ['tesseract'];
+  }
+
+  private getProviderPriority(): string[] {
+    const priority =
+      this.primaryProvider === 'auto'
+        ? [...this.getDefaultProviderPriority(), ...this.fallbackProviders]
+        : [this.primaryProvider, ...this.fallbackProviders];
+
+    return [...new Set(priority)];
+  }
+
+  private async getAvailableProviderChain(): Promise<OCRProvider[]> {
+    await this.initializeProviders();
+
+    const providerPriority = this.getProviderPriority();
+    const providerChecks = providerPriority.map(async (providerName) => {
+      const provider = this.providers.get(providerName);
+      if (!provider)
+        return { name: providerName, available: false, provider: null };
+
+      try {
+        const deps = await provider.checkDependencies();
+        return {
+          name: providerName,
+          available: deps.available,
+          provider: deps.available ? provider : null,
+          error: deps.error,
+        };
+      } catch (error) {
+        console.debug(`OCR provider '${providerName}' check failed:`, error);
+        return { name: providerName, available: false, provider: null };
+      }
+    });
+
+    const results = await Promise.all(providerChecks);
+    const providers: OCRProvider[] = [];
+
+    for (const providerName of providerPriority) {
+      const result = results.find((r) => r.name === providerName);
+      if (result?.available && result.provider) {
+        providers.push(result.provider);
+        continue;
+      }
+
+      if (result && !result.available && result.error) {
+        const log =
+          this.primaryProvider !== 'auto' &&
+          providerName === this.primaryProvider
+            ? console.warn
+            : console.debug;
+        log(`OCR provider '${providerName}' not available:`, result.error);
+      }
+    }
+
+    return providers;
   }
 
   /**
@@ -438,76 +439,58 @@ export class OCRFactory {
     // Merge default options with provided options
     const mergedOptions = { ...this.defaultOptions, ...options };
 
-    // Get the best available provider
-    const provider = await this.getBestProvider();
-    if (!provider) {
+    const providers = await this.getAvailableProviderChain();
+    if (providers.length === 0) {
       throw new OCRDependencyError('none', 'No OCR providers are available');
     }
 
-    try {
-      const startTime = Date.now();
-      const result = await provider.performOCR(images, mergedOptions);
-      const processingTime = Date.now() - startTime;
+    let firstEmptyResult: OCRResult | null = null;
+    let firstProviderName: string | undefined;
+    let lastError: unknown;
 
-      // Enhance result with metadata
-      result.metadata = {
-        ...result.metadata,
-        processingTime,
-        provider: provider.name,
-        language: mergedOptions.language,
-      };
+    for (const provider of providers) {
+      firstProviderName ??= provider.name;
 
-      // If result is empty and we have fallback providers, try them
-      if (
-        (!result.text || result.text.trim().length === 0) &&
-        this.fallbackProviders.length > 0
-      ) {
-        for (const fallbackName of this.fallbackProviders) {
-          if (fallbackName === provider.name) continue; // Skip if it's the same provider
+      try {
+        const startTime = Date.now();
+        const result = await provider.performOCR(images, mergedOptions);
+        const processingTime = Date.now() - startTime;
 
-          const fallbackProvider = this.providers.get(fallbackName);
-          if (fallbackProvider) {
-            try {
-              const deps = await fallbackProvider.checkDependencies();
-              if (deps.available) {
-                const fallbackResult = await fallbackProvider.performOCR(
-                  images,
-                  mergedOptions,
-                );
-                if (
-                  fallbackResult.text &&
-                  fallbackResult.text.trim().length > 0
-                ) {
-                  console.info(
-                    `OCR fallback to '${fallbackName}' provider succeeded`,
-                  );
-                  fallbackResult.metadata = {
-                    ...fallbackResult.metadata,
-                    provider: fallbackProvider.name,
-                    fallbackFrom: provider.name,
-                  };
-                  return fallbackResult;
-                }
-              }
-            } catch (fallbackError) {
-              console.warn(
-                `OCR fallback provider '${fallbackName}' failed:`,
-                fallbackError,
-              );
-            }
+        // Enhance result with metadata
+        result.metadata = {
+          ...result.metadata,
+          processingTime,
+          provider: provider.name,
+          language: mergedOptions.language,
+        };
+
+        if (result.text?.trim()) {
+          if (provider.name !== firstProviderName) {
+            console.info(
+              `OCR fallback to '${provider.name}' provider succeeded`,
+            );
+            result.metadata.fallbackFrom = firstProviderName;
           }
-        }
-      }
 
-      return result;
-    } catch (error) {
-      console.error(`OCR provider '${provider.name}' failed:`, error);
-      throw new OCRError(
-        `OCR processing failed: ${(error as Error).message}`,
-        provider.name,
-        error,
-      );
+          return result;
+        }
+
+        firstEmptyResult ??= result;
+      } catch (error) {
+        console.error(`OCR provider '${provider.name}' failed:`, error);
+        lastError = error;
+      }
     }
+
+    if (firstEmptyResult) {
+      return firstEmptyResult;
+    }
+
+    throw new OCRError(
+      `OCR processing failed: ${(lastError as Error)?.message ?? 'all providers failed'}`,
+      firstProviderName,
+      lastError,
+    );
   }
 
   /**


### PR DESCRIPTION
## Summary

- Continue through the automatic OCR provider chain when the first available provider returns empty text instead of treating the empty result as success.
- Tighten ONNX raw-RGB detection so encoded PNG buffers with dimensions are decoded instead of misread as raw pixels.
- Add regressions for empty auto-provider fallback and encoded PNG handling.

## Root Cause

The auto provider selected ONNX first and returned a structurally successful but empty OCR result. PDF extraction accepted that empty result, so image-only Bentley meeting minutes produced no text and Praeco skipped article generation.

## Validation

- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
- `pnpm lint` (exited 0; reported existing Biome info/warnings)
- `pnpm docs:api:check`
- `pnpm test:coverage`

Note: local Node is `v22.22.3`, while the package engine now requests `>=24`, so pnpm printed engine warnings during validation.