### PR TITLE
fix(ocr): quiet optional auto provider logs

### DIFF
--- a/.changeset/quiet-auto-provider-checks.md
+++ b/.changeset/quiet-auto-provider-checks.md
@@ -1,0 +1,5 @@
+---
+'@happyvertical/ocr': patch
+---
+
+Suppress optional OCR provider availability logs in auto mode when another provider is available.

--- a/docs/api/classes/OCRFactory.md
+++ b/docs/api/classes/OCRFactory.md
@@ -158,7 +158,7 @@ if (provider) {
 
 > **performOCR**(`images`, `options?`): `Promise`\<[`OCRResult`](../interfaces/OCRResult.md)\>
 
-Defined in: [src/shared/factory.ts:423](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L423)
+Defined in: [src/shared/factory.ts:428](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L428)
 
 Perform OCR processing on one or more images.
 
@@ -245,7 +245,7 @@ try {
 
 > **getProvidersInfo**(): `Promise`\<[`OCRProviderInfo`](../interfaces/OCRProviderInfo.md)[]\>
 
-Defined in: [src/shared/factory.ts:519](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L519)
+Defined in: [src/shared/factory.ts:524](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L524)
 
 Get detailed information about all OCR providers.
 
@@ -280,7 +280,7 @@ providers.forEach(provider => {
 
 > **isOCRAvailable**(): `Promise`\<`boolean`\>
 
-Defined in: [src/shared/factory.ts:571](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L571)
+Defined in: [src/shared/factory.ts:576](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L576)
 
 Check if OCR functionality is available in the current environment.
 
@@ -309,7 +309,7 @@ if (await factory.isOCRAvailable()) {
 
 > **getSupportedLanguages**(): `Promise`\<`string`[]\>
 
-Defined in: [src/shared/factory.ts:596](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L596)
+Defined in: [src/shared/factory.ts:601](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L601)
 
 Get array of supported language codes from the best available provider.
 
@@ -341,7 +341,7 @@ const result = await factory.performOCR(images, {
 
 > **cleanup**(): `Promise`\<`void`\>
 
-Defined in: [src/shared/factory.ts:633](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L633)
+Defined in: [src/shared/factory.ts:638](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L638)
 
 Clean up all OCR providers and release their resources.
 
@@ -382,7 +382,7 @@ process.on('SIGINT', async () => {
 
 > **addProvider**(`name`, `provider`): `void`
 
-Defined in: [src/shared/factory.ts:671](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L671)
+Defined in: [src/shared/factory.ts:676](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L676)
 
 Add a custom OCR provider to the factory.
 
@@ -429,7 +429,7 @@ const customFactory = new OCRFactory({ provider: 'custom' });
 
 > **removeProvider**(`name`): `Promise`\<`void`\>
 
-Defined in: [src/shared/factory.ts:689](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L689)
+Defined in: [src/shared/factory.ts:694](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L694)
 
 Remove an OCR provider from the factory.
 
@@ -461,7 +461,7 @@ await factory.removeProvider('custom');
 
 > **getAvailableProviderNames**(): `string`[]
 
-Defined in: [src/shared/factory.ts:714](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L714)
+Defined in: [src/shared/factory.ts:719](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L719)
 
 Get array of provider names that have been loaded in the current environment.
 
@@ -490,7 +490,7 @@ console.log('Loaded providers:', providerNames);
 
 > **getEnvironment**(): [`OCREnvironment`](../type-aliases/OCREnvironment.md)
 
-Defined in: [src/shared/factory.ts:733](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L733)
+Defined in: [src/shared/factory.ts:738](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L738)
 
 Get the detected runtime environment.
 

--- a/docs/api/functions/getAvailableProviders.md
+++ b/docs/api/functions/getAvailableProviders.md
@@ -8,7 +8,7 @@
 
 > **getAvailableProviders**(): `Promise`\<`string`[]\>
 
-Defined in: [src/shared/factory.ts:863](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L863)
+Defined in: [src/shared/factory.ts:882](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L882)
 
 Get list of OCR provider names available in the current environment.
 

--- a/docs/api/functions/getOCR.md
+++ b/docs/api/functions/getOCR.md
@@ -8,7 +8,7 @@
 
 > **getOCR**(`options?`): [`OCRFactory`](../classes/OCRFactory.md)
 
-Defined in: [src/shared/factory.ts:799](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L799)
+Defined in: [src/shared/factory.ts:818](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L818)
 
 Get or create an OCR factory instance with automatic provider selection.
 

--- a/docs/api/functions/getProviderInfo.md
+++ b/docs/api/functions/getProviderInfo.md
@@ -8,7 +8,7 @@
 
 > **getProviderInfo**(`providerName`): `Promise`\<[`OCRProviderInfo`](../interfaces/OCRProviderInfo.md) \| `null`\>
 
-Defined in: [src/shared/factory.ts:937](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L937)
+Defined in: [src/shared/factory.ts:956](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L956)
 
 Get detailed information about a specific OCR provider.
 

--- a/docs/api/functions/isProviderAvailable.md
+++ b/docs/api/functions/isProviderAvailable.md
@@ -8,7 +8,7 @@
 
 > **isProviderAvailable**(`providerName`): `Promise`\<`boolean`\>
 
-Defined in: [src/shared/factory.ts:891](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L891)
+Defined in: [src/shared/factory.ts:910](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L910)
 
 Check if a specific OCR provider is available and ready to use.
 

--- a/docs/api/functions/resetOCRFactory.md
+++ b/docs/api/functions/resetOCRFactory.md
@@ -8,7 +8,7 @@
 
 > **resetOCRFactory**(): `void`
 
-Defined in: [src/shared/factory.ts:833](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L833)
+Defined in: [src/shared/factory.ts:852](https://github.com/happyvertical/ocr/blob/main/src/shared/factory.ts#L852)
 
 Reset the global OCR factory instance.
 

--- a/src/shared/factory.spec.ts
+++ b/src/shared/factory.spec.ts
@@ -42,6 +42,7 @@ describe('OCRFactory environment variable configuration', () => {
     process.env = { ...originalEnv };
     // Reset factory after each test
     resetOCRFactory();
+    vi.restoreAllMocks();
   });
 
   test('should load provider from HAVE_OCR_PROVIDER', () => {
@@ -341,6 +342,115 @@ describe('OCRFactory environment variable configuration', () => {
     expect(result.metadata?.fallbackFrom).toBe('onnx');
     expect(onnx.performOCR).toHaveBeenCalledTimes(1);
     expect(tesseract.performOCR).toHaveBeenCalledTimes(1);
+  });
+
+  test('should suppress unavailable auto provider logs when another provider is available', async () => {
+    const debug = vi
+      .spyOn(console, 'debug')
+      .mockImplementation(() => undefined);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const onnx = createMockProvider({ name: 'onnx' });
+    const tesseract = createMockProvider({
+      name: 'tesseract',
+      checkDependencies: vi.fn().mockResolvedValue({
+        available: false,
+        error: 'Tesseract missing',
+        details: {},
+      }),
+    });
+    const litellm = createMockProvider({
+      name: 'litellm',
+      checkDependencies: vi.fn().mockResolvedValue({
+        available: false,
+        error: 'LiteLLM API key not configured',
+        details: {},
+      }),
+    });
+    const factory = new OCRFactory({ provider: 'auto' });
+    (factory as any).initialized = true;
+    factory.addProvider('onnx', onnx);
+    factory.addProvider('tesseract', tesseract);
+    factory.addProvider('litellm', litellm);
+
+    const providers = await (factory as any).getAvailableProviderChain();
+
+    expect(providers.map((provider: OCRProvider) => provider.name)).toEqual([
+      'onnx',
+    ]);
+    expect(debug).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  test('should log unavailable auto providers when no providers are available', async () => {
+    const debug = vi
+      .spyOn(console, 'debug')
+      .mockImplementation(() => undefined);
+    const onnx = createMockProvider({
+      name: 'onnx',
+      checkDependencies: vi.fn().mockResolvedValue({
+        available: false,
+        error: 'ONNX missing',
+        details: {},
+      }),
+    });
+    const tesseract = createMockProvider({
+      name: 'tesseract',
+      checkDependencies: vi.fn().mockResolvedValue({
+        available: false,
+        error: 'Tesseract missing',
+        details: {},
+      }),
+    });
+    const factory = new OCRFactory({ provider: 'auto' });
+    (factory as any).initialized = true;
+    factory.addProvider('onnx', onnx);
+    factory.addProvider('tesseract', tesseract);
+
+    const providers = await (factory as any).getAvailableProviderChain();
+
+    expect(providers).toEqual([]);
+    expect(debug).toHaveBeenCalledWith(
+      "OCR provider 'onnx' not available:",
+      'ONNX missing',
+    );
+    expect(debug).toHaveBeenCalledWith(
+      "OCR provider 'tesseract' not available:",
+      'Tesseract missing',
+    );
+  });
+
+  test('should warn when the requested primary provider is unavailable', async () => {
+    const debug = vi
+      .spyOn(console, 'debug')
+      .mockImplementation(() => undefined);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const onnx = createMockProvider({
+      name: 'onnx',
+      checkDependencies: vi.fn().mockResolvedValue({
+        available: false,
+        error: 'ONNX missing',
+        details: {},
+      }),
+    });
+    const tesseract = createMockProvider({ name: 'tesseract' });
+    const factory = new OCRFactory({
+      provider: 'onnx',
+      fallbackProviders: ['tesseract'],
+    });
+    (factory as any).initialized = true;
+    factory.addProvider('onnx', onnx);
+    factory.addProvider('tesseract', tesseract);
+
+    const providers = await (factory as any).getAvailableProviderChain();
+
+    expect(providers.map((provider: OCRProvider) => provider.name)).toEqual([
+      'tesseract',
+    ]);
+    expect(warn).toHaveBeenCalledWith(
+      "OCR provider 'onnx' not available:",
+      'ONNX missing',
+    );
+    expect(debug).not.toHaveBeenCalled();
   });
 
   test('should ignore unavailable or failing fallback providers', async () => {

--- a/src/shared/factory.ts
+++ b/src/shared/factory.ts
@@ -338,12 +338,12 @@ export class OCRFactory {
           error: deps.error,
         };
       } catch (error) {
-        console.debug(`OCR provider '${providerName}' check failed:`, error);
-        return { name: providerName, available: false, provider: null };
+        return { name: providerName, available: false, provider: null, error };
       }
     });
 
     const results = await Promise.all(providerChecks);
+    const hasAvailableProvider = results.some((result) => result.available);
     const providers: OCRProvider[] = [];
 
     for (const providerName of providerPriority) {
@@ -353,7 +353,12 @@ export class OCRFactory {
         continue;
       }
 
-      if (result && !result.available && result.error) {
+      if (
+        result &&
+        !result.available &&
+        result.error &&
+        this.shouldLogUnavailableProvider(providerName, hasAvailableProvider)
+      ) {
         const log =
           this.primaryProvider !== 'auto' &&
           providerName === this.primaryProvider
@@ -732,6 +737,20 @@ export class OCRFactory {
    */
   getEnvironment(): OCREnvironment {
     return this.environment;
+  }
+
+  private shouldLogUnavailableProvider(
+    providerName: string,
+    hasAvailableProvider: boolean,
+  ): boolean {
+    if (
+      this.primaryProvider !== 'auto' &&
+      providerName === this.primaryProvider
+    ) {
+      return true;
+    }
+
+    return !hasAvailableProvider;
   }
 }
 


### PR DESCRIPTION
## Summary
- suppress unavailable optional provider logs in auto mode when another OCR provider is available
- preserve warnings for an explicitly requested primary provider that is unavailable
- add regression coverage for healthy auto mode, fully unavailable auto mode, and requested-primary fallback
- add a patch changeset for the next @happyvertical/ocr release

## Context
Anytown staging/prod were showing repeated `OCR provider 'litellm' not available` messages even when PDF/OCR extraction was healthy. The core issue is that auto mode checks all candidate providers and logged optional provider dependency errors after a successful local provider check, making a healthy OCR runtime look misconfigured.

Related Anytown staging issue: anytown/anytown.ai#575

## Validation
- `fnm exec --using 24 pnpm exec vitest run src/shared/factory.spec.ts --testTimeout 120000`
- `fnm exec --using 24 pnpm typecheck`
- `fnm exec --using 24 pnpm build`
- `fnm exec --using 24 pnpm lint` (exits 0; reports existing warning/info diagnostics)
- `fnm exec --using 24 pnpm test:coverage`
