### PR TITLE
ci: require latest validation gate result

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -25,10 +25,10 @@ concurrency:
       (github.event_name == 'pull_request' &&
       !contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
       !(github.event.action == 'edited' && github.event.changes.base != null))) &&
-      'lifecycle' ||
+      format('lifecycle-{0}', github.run_id) ||
       'validation'
     }}
-  cancel-in-progress: ${{ !(github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && !contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) && !(github.event.action == 'edited' && github.event.changes.base != null))) }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -21,6 +21,11 @@ concurrency:
       github.event.merge_group.head_sha ||
       github.ref
     }}-${{
+      (github.event_name == 'pull_request' &&
+      github.event.action == 'edited' &&
+      github.event.changes.title != null &&
+      github.event.changes.base == null) &&
+      'title' ||
       (github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' &&
       !contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -25,7 +25,7 @@ concurrency:
       (github.event_name == 'pull_request' &&
       !contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
       !(github.event.action == 'edited' && github.event.changes.base != null))) &&
-      format('lifecycle-{0}', github.run_id) ||
+      'lifecycle' ||
       'validation'
     }}
   cancel-in-progress: true

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -28,7 +28,13 @@ concurrency:
       'lifecycle' ||
       'validation'
     }}
-  cancel-in-progress: true
+  cancel-in-progress: >-
+    ${{ !(
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+      !contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
+      !(github.event.action == 'edited' && github.event.changes.base != null))
+    ) }}
 
 permissions:
   contents: read
@@ -101,7 +107,8 @@ jobs:
     if: >-
       github.event_name == 'pull_request' &&
       (contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) ||
-      (github.event.action == 'edited' && github.event.changes.base != null))
+      (github.event.action == 'edited' &&
+      (github.event.changes.base != null || github.event.changes.title != null)))
     runs-on: arc-happyvertical
 
     steps:
@@ -209,6 +216,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           EVENT_ACTION: ${{ github.event.action }}
           BASE_CHANGED: ${{ github.event.changes.base != null }}
+          TITLE_CHANGED: ${{ github.event.changes.title != null }}
           PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
           EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
           LIFECYCLE: ${{ needs.lifecycle.result }}
@@ -235,6 +243,9 @@ jobs:
           fi
 
           if [ "$full_validation" = false ]; then
+            if [ "$EVENT_NAME" = pull_request ] && [ "$EVENT_ACTION" = edited ] && [ "$TITLE_CHANGED" = true ]; then
+              require_success 'Conventional commits' "$COMMITS"
+            fi
             head_sha="$EVENT_HEAD_SHA"
             if [ "$EVENT_NAME" = workflow_dispatch ]; then
               head_sha=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq .head.sha)
@@ -247,7 +258,7 @@ jobs:
               exit 1
             fi
             latest=$(printf '%s\n' "$checks" | jq -r \
-              '[.check_runs[] | select(.name == "Required CI" and .status == "completed" and .conclusion != "cancelled")] | sort_by(.completed_at) | reverse | .[0].conclusion // "missing"')
+              '[.check_runs[] | select(.name == "Required CI" and .status == "completed")] | sort_by(.completed_at) | reverse | .[0].conclusion // "missing"')
             if [ "$latest" != success ]; then
               echo "::error::Latest completed Required CI for $head_sha must pass, got: $latest"
               exit 1

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -194,7 +194,7 @@ jobs:
       HAVE_RELEASE_APP_PRIVATE_KEY: ${{ secrets.HAVE_RELEASE_APP_PRIVATE_KEY }}
 
   validation-gate:
-    name: Required CI / validation
+    name: ${{ (github.event_name == 'merge_group' || (github.event_name == 'pull_request' && (contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) || (github.event.action == 'edited' && github.event.changes.base != null)))) && 'Required CI / validation' || 'Required CI / validation (inactive)' }}
     if: >-
       always() &&
       (github.event_name == 'merge_group' ||

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -289,15 +289,37 @@ jobs:
     if: always()
     needs: [validation-gate, metadata-gate]
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      checks: read
+      contents: read
+      pull-requests: read
     steps:
       - name: Require the event-appropriate gate
         env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           VALIDATION: ${{ needs.validation-gate.result }}
           METADATA: ${{ needs.metadata-gate.result }}
         run: |
-          if { [ "$VALIDATION" = success ] && [ "$METADATA" = skipped ]; } ||
-             { [ "$VALIDATION" = skipped ] && [ "$METADATA" = success ]; }; then
+          set -euo pipefail
+          if [ "$VALIDATION" = success ] && [ "$METADATA" = skipped ]; then
             exit 0
+          fi
+          if [ "$VALIDATION" = skipped ] && [ "$METADATA" = success ]; then
+            head_sha="$EVENT_HEAD_SHA"
+            if [ "${{ github.event_name }}" = workflow_dispatch ]; then
+              head_sha=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq .head.sha)
+            fi
+            checks=$(gh api "repos/$GITHUB_REPOSITORY/commits/$head_sha/check-runs?check_name=Required%20CI%20%2F%20validation&filter=all&per_page=100")
+            pending=$(printf '%s\n' "$checks" | jq --arg current_run "/actions/runs/$GITHUB_RUN_ID/" '[.check_runs[] | select(.name == "Required CI / validation" and .status != "completed") | select(((.details_url // "") | contains($current_run)) | not)] | length')
+            latest=$(printf '%s\n' "$checks" | jq -r '[.check_runs[] | select(.name == "Required CI / validation" and .status == "completed" and .conclusion != "skipped")] | sort_by(.completed_at) | reverse | .[0].conclusion // "missing"')
+            if [ "$pending" -eq 0 ] && [ "$latest" = success ]; then
+              exit 0
+            fi
+            echo "::error::Final validation baseline for $head_sha is pending=$pending latest=$latest"
+            exit 1
           fi
           echo "::error::Expected exactly one successful gate; validation=$VALIDATION metadata=$METADATA"
           exit 1

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -195,12 +195,7 @@ jobs:
 
   validation-gate:
     name: >-
-      ${{ (github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' &&
-      !contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
-      !(github.event.action == 'edited' && github.event.changes.base != null))) &&
-      'Required CI / inactive validation' ||
-      'Required CI / validation' }}
+      Required CI / ${{ (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && !contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) && !(github.event.action == 'edited' && github.event.changes.base != null))) && 'inactive validation' || 'validation' }}
     if: >-
       always() &&
       (github.event_name == 'merge_group' ||

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -28,13 +28,7 @@ concurrency:
       'lifecycle' ||
       'validation'
     }}
-  cancel-in-progress: >-
-    ${{ !(
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' &&
-      !contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
-      !(github.event.action == 'edited' && github.event.changes.base != null))
-    ) }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -199,9 +193,14 @@ jobs:
       HAVE_RELEASE_APP_ID: ${{ secrets.HAVE_RELEASE_APP_ID }}
       HAVE_RELEASE_APP_PRIVATE_KEY: ${{ secrets.HAVE_RELEASE_APP_PRIVATE_KEY }}
 
-  required-ci:
-    name: Required CI
-    if: always()
+  validation-gate:
+    name: Required CI / validation
+    if: >-
+      always() &&
+      (github.event_name == 'merge_group' ||
+      (github.event_name == 'pull_request' &&
+      (contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) ||
+      (github.event.action == 'edited' && github.event.changes.base != null))))
     needs: [lifecycle, validate-commits, test]
     runs-on: ubuntu-latest
     permissions:
@@ -232,41 +231,6 @@ jobs:
           }
 
           require_success 'Lifecycle policy' "$LIFECYCLE"
-          full_validation=false
-          if [ "$EVENT_NAME" = merge_group ]; then
-            full_validation=true
-          elif [ "$EVENT_NAME" = pull_request ] && {
-            [[ "$EVENT_ACTION" =~ ^(opened|synchronize|reopened)$ ]] ||
-              { [ "$EVENT_ACTION" = edited ] && [ "$BASE_CHANGED" = true ]; }
-          }; then
-            full_validation=true
-          fi
-
-          if [ "$full_validation" = false ]; then
-            if [ "$EVENT_NAME" = pull_request ] && [ "$EVENT_ACTION" = edited ] && [ "$TITLE_CHANGED" = true ]; then
-              require_success 'Conventional commits' "$COMMITS"
-            fi
-            head_sha="$EVENT_HEAD_SHA"
-            if [ "$EVENT_NAME" = workflow_dispatch ]; then
-              head_sha=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq .head.sha)
-            fi
-            checks=$(gh api "repos/$GITHUB_REPOSITORY/commits/$head_sha/check-runs?check_name=Required%20CI&filter=all&per_page=100")
-            other_pending=$(printf '%s\n' "$checks" | jq --arg current_run "/actions/runs/$GITHUB_RUN_ID/" \
-              '[.check_runs[] | select(.name == "Required CI" and .status != "completed") | select(((.details_url // "") | contains($current_run)) | not)] | length')
-            if [ "$other_pending" -gt 0 ]; then
-              echo "::error::Another Required CI is still running for $head_sha"
-              exit 1
-            fi
-            latest=$(printf '%s\n' "$checks" | jq -r \
-              '[.check_runs[] | select(.name == "Required CI" and .status == "completed")] | sort_by(.completed_at) | reverse | .[0].conclusion // "missing"')
-            if [ "$latest" != success ]; then
-              echo "::error::Latest completed Required CI for $head_sha must pass, got: $latest"
-              exit 1
-            fi
-            echo "Preserved the latest successful Required CI for $head_sha after lifecycle-only event."
-            exit 0
-          fi
-
           require_success 'Tests' "$TEST"
           if [ "$EVENT_NAME" = pull_request ]; then
             require_success 'Conventional commits' "$COMMITS"
@@ -274,4 +238,66 @@ jobs:
             echo "::error::Conventional commits should be skipped for $EVENT_NAME, got: $COMMITS"
             exit 1
           fi
-          echo "Required CI passed for $EVENT_NAME"
+          echo "Validation baseline passed for $EVENT_NAME"
+
+  metadata-gate:
+    name: Required CI / metadata
+    if: >-
+      always() &&
+      (github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+      !contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
+      !(github.event.action == 'edited' && github.event.changes.base != null)))
+    needs: [lifecycle, validate-commits]
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      checks: read
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Preserve validation baseline
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_ACTION: ${{ github.event.action }}
+          TITLE_CHANGED: ${{ github.event.changes.title != null }}
+          PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          LIFECYCLE: ${{ needs.lifecycle.result }}
+          COMMITS: ${{ needs.validate-commits.result }}
+        run: |
+          set -euo pipefail
+          [ "$LIFECYCLE" = success ] || { echo "::error::Lifecycle policy failed: $LIFECYCLE"; exit 1; }
+          if [ "$EVENT_ACTION" = edited ] && [ "$TITLE_CHANGED" = true ] && [ "$COMMITS" != success ]; then
+            echo "::error::Conventional title validation failed: $COMMITS"
+            exit 1
+          fi
+          head_sha="$EVENT_HEAD_SHA"
+          if [ "${{ github.event_name }}" = workflow_dispatch ]; then
+            head_sha=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq .head.sha)
+          fi
+          checks=$(gh api "repos/$GITHUB_REPOSITORY/commits/$head_sha/check-runs?check_name=Required%20CI%20%2F%20validation&filter=all&per_page=100")
+          pending=$(printf '%s\n' "$checks" | jq --arg current_run "/actions/runs/$GITHUB_RUN_ID/" '[.check_runs[] | select(.name == "Required CI / validation" and .status != "completed") | select(((.details_url // "") | contains($current_run)) | not)] | length')
+          latest=$(printf '%s\n' "$checks" | jq -r '[.check_runs[] | select(.name == "Required CI / validation" and .status == "completed" and .conclusion != "skipped")] | sort_by(.completed_at) | reverse | .[0].conclusion // "missing"')
+          if [ "$pending" -gt 0 ] || [ "$latest" != success ]; then
+            echo "::error::Validation baseline for $head_sha is pending=$pending latest=$latest"
+            exit 1
+          fi
+
+  required-ci:
+    name: Required CI
+    if: always()
+    needs: [validation-gate, metadata-gate]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require the event-appropriate gate
+        env:
+          VALIDATION: ${{ needs.validation-gate.result }}
+          METADATA: ${{ needs.metadata-gate.result }}
+        run: |
+          if { [ "$VALIDATION" = success ] && [ "$METADATA" = skipped ]; } ||
+             { [ "$VALIDATION" = skipped ] && [ "$METADATA" = success ]; }; then
+            exit 0
+          fi
+          echo "::error::Expected exactly one successful gate; validation=$VALIDATION metadata=$METADATA"
+          exit 1

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -28,7 +28,7 @@ concurrency:
       'lifecycle' ||
       'validation'
     }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ !(github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && !contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) && !(github.event.action == 'edited' && github.event.changes.base != null))) }}
 
 permissions:
   contents: read
@@ -194,7 +194,7 @@ jobs:
       HAVE_RELEASE_APP_PRIVATE_KEY: ${{ secrets.HAVE_RELEASE_APP_PRIVATE_KEY }}
 
   validation-gate:
-    name: ${{ (github.event_name == 'merge_group' || (github.event_name == 'pull_request' && (contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) || (github.event.action == 'edited' && github.event.changes.base != null)))) && 'Required CI / validation' || 'Required CI / validation (inactive)' }}
+    name: Required CI / validation
     if: >-
       always() &&
       (github.event_name == 'merge_group' ||

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -239,8 +239,15 @@ jobs:
             if [ "$EVENT_NAME" = workflow_dispatch ]; then
               head_sha=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq .head.sha)
             fi
-            latest=$(gh api "repos/$GITHUB_REPOSITORY/commits/$head_sha/check-runs?check_name=Required%20CI&filter=all&per_page=100" \
-              --jq '[.check_runs[] | select(.name == "Required CI" and .status == "completed")] | sort_by(.completed_at) | reverse | .[0].conclusion // "missing"')
+            checks=$(gh api "repos/$GITHUB_REPOSITORY/commits/$head_sha/check-runs?check_name=Required%20CI&filter=all&per_page=100")
+            other_pending=$(printf '%s\n' "$checks" | jq --arg current_run "/actions/runs/$GITHUB_RUN_ID/" \
+              '[.check_runs[] | select(.name == "Required CI" and .status != "completed") | select(((.details_url // "") | contains($current_run)) | not)] | length')
+            if [ "$other_pending" -gt 0 ]; then
+              echo "::error::Another Required CI is still running for $head_sha"
+              exit 1
+            fi
+            latest=$(printf '%s\n' "$checks" | jq -r \
+              '[.check_runs[] | select(.name == "Required CI" and .status == "completed" and .conclusion != "cancelled")] | sort_by(.completed_at) | reverse | .[0].conclusion // "missing"')
             if [ "$latest" != success ]; then
               echo "::error::Latest completed Required CI for $head_sha must pass, got: $latest"
               exit 1

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -239,13 +239,13 @@ jobs:
             if [ "$EVENT_NAME" = workflow_dispatch ]; then
               head_sha=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq .head.sha)
             fi
-            prior=$(gh api "repos/$GITHUB_REPOSITORY/commits/$head_sha/check-runs?check_name=Required%20CI&filter=all&per_page=100" \
-              --jq '[.check_runs[] | select(.name == "Required CI" and .status == "completed" and .conclusion == "success")] | length')
-            if [ "$prior" -lt 1 ]; then
-              echo "::error::No prior successful full Required CI exists for $head_sha"
+            latest=$(gh api "repos/$GITHUB_REPOSITORY/commits/$head_sha/check-runs?check_name=Required%20CI&filter=all&per_page=100" \
+              --jq '[.check_runs[] | select(.name == "Required CI" and .status == "completed")] | sort_by(.completed_at) | reverse | .[0].conclusion // "missing"')
+            if [ "$latest" != success ]; then
+              echo "::error::Latest completed Required CI for $head_sha must pass, got: $latest"
               exit 1
             fi
-            echo "Preserved prior successful Required CI for $head_sha after lifecycle-only event."
+            echo "Preserved the latest successful Required CI for $head_sha after lifecycle-only event."
             exit 0
           fi
 

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -194,7 +194,13 @@ jobs:
       HAVE_RELEASE_APP_PRIVATE_KEY: ${{ secrets.HAVE_RELEASE_APP_PRIVATE_KEY }}
 
   validation-gate:
-    name: Required CI / validation
+    name: >-
+      ${{ (github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+      !contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
+      !(github.event.action == 'edited' && github.event.changes.base != null))) &&
+      'Required CI / inactive validation' ||
+      'Required CI / validation' }}
     if: >-
       always() &&
       (github.event_name == 'merge_group' ||

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -249,6 +249,8 @@ jobs:
       !contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
       !(github.event.action == 'edited' && github.event.changes.base != null)))
     needs: [lifecycle, validate-commits]
+    outputs:
+      prerequisites-passed: ${{ steps.prerequisites.outputs.passed }}
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -256,13 +258,11 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - name: Preserve validation baseline
+      - name: Validate metadata prerequisites
+        id: prerequisites
         env:
-          GH_TOKEN: ${{ github.token }}
           EVENT_ACTION: ${{ github.event.action }}
           TITLE_CHANGED: ${{ github.event.changes.title != null }}
-          PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
-          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           LIFECYCLE: ${{ needs.lifecycle.result }}
           COMMITS: ${{ needs.validate-commits.result }}
         run: |
@@ -272,6 +272,14 @@ jobs:
             echo "::error::Conventional title validation failed: $COMMITS"
             exit 1
           fi
+          echo "passed=true" >> "$GITHUB_OUTPUT"
+      - name: Preserve validation baseline
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
           head_sha="$EVENT_HEAD_SHA"
           if [ "${{ github.event_name }}" = workflow_dispatch ]; then
             head_sha=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq .head.sha)
@@ -302,12 +310,13 @@ jobs:
           EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           VALIDATION: ${{ needs.validation-gate.result }}
           METADATA: ${{ needs.metadata-gate.result }}
+          METADATA_PREREQUISITES: ${{ needs.metadata-gate.outputs.prerequisites-passed }}
         run: |
           set -euo pipefail
           if [ "$VALIDATION" = success ] && [ "$METADATA" = skipped ]; then
             exit 0
           fi
-          if [ "$VALIDATION" = skipped ] && [ "$METADATA" = success ]; then
+          if [ "$VALIDATION" = skipped ] && [ "$METADATA_PREREQUISITES" = true ]; then
             head_sha="$EVENT_HEAD_SHA"
             if [ "${{ github.event_name }}" = workflow_dispatch ]; then
               head_sha=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq .head.sha)
@@ -321,5 +330,5 @@ jobs:
             echo "::error::Final validation baseline for $head_sha is pending=$pending latest=$latest"
             exit 1
           fi
-          echo "::error::Expected exactly one successful gate; validation=$VALIDATION metadata=$METADATA"
+          echo "::error::Expected exactly one valid gate; validation=$VALIDATION metadata=$METADATA metadata_prerequisites=$METADATA_PREREQUISITES"
           exit 1


### PR DESCRIPTION
## Summary

- preserve only the latest completed Required CI result during lifecycle-only events
- fail closed when the latest full validation failed or is missing

Closes #109

## Validation

- actionlint on .github/workflows/on-pull-request.yml
- pnpm typecheck
- git diff --check

<!-- hv-agent-run:v1 -->
{"schema":"hv-agent-run:v1","runtime":"codex","session":"codex-ocr-latest-gate-20260713T0049Z","issue":"https://github.com/happyvertical/ocr/issues/109","policy_revision":"1.0.0","validation":["actionlint","pnpm typecheck","git diff --check"]}