### PR TITLE
fix(ocr): defer native runtime loading

### DIFF
--- a/.changeset/lazy-native-ocr-runtime.md
+++ b/.changeset/lazy-native-ocr-runtime.md
@@ -1,0 +1,5 @@
+---
+'@happyvertical/ocr': patch
+---
+
+Defer loading the Sharp and ONNX Runtime native addons until the ONNX provider performs OCR, preventing provider discovery from destabilizing consumers that also load Kreuzberg or other native runtimes.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ yarn add @happyvertical/ocr
 bun add @happyvertical/ocr
 ```
 
-The package includes Tesseract.js by default, a PaddleOCR ONNX provider with package-owned Sharp 0.35 and ONNX Runtime dependencies, LLM-backed OCR through `@happyvertical/ai`, and a Node.js provider for Baidu Unlimited-OCR when you run it behind SGLang or Bifrost. PaddleOCR model assets continue to load from `@gutenye/ocr-models`; no model binaries are checked into this repository.
+The package includes Tesseract.js by default, a PaddleOCR ONNX provider with package-owned Sharp 0.35 and ONNX Runtime dependencies, LLM-backed OCR through `@happyvertical/ai`, and a Node.js provider for Baidu Unlimited-OCR when you run it behind SGLang or Bifrost. PaddleOCR model assets continue to load from `@gutenye/ocr-models`; no model binaries are checked into this repository. Provider discovery does not load the Sharp or ONNX Runtime native addons. Dependency checks validate both addons in an isolated child process, and the ONNX provider loads them in the consumer process only when it performs its first OCR operation. This keeps discovery and dependency checks safe in processes that also use native document or image libraries such as Kreuzberg and Sharp.
 
 ## Quick Start
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@changesets/cli": "^2.31.0",
     "@commitlint/cli": "^21.2.1",
     "@commitlint/config-conventional": "^21.2.0",
+    "@kreuzberg/node": "4.10.2",
     "@types/node": "24.13.3",
     "@vitest/coverage-v8": "4.1.10",
     "lefthook": "2.1.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       '@commitlint/config-conventional':
         specifier: ^21.2.0
         version: 21.2.0
+      '@kreuzberg/node':
+        specifier: 4.10.2
+        version: 4.10.2
       '@types/node':
         specifier: 24.13.3
         version: 24.13.3
@@ -451,6 +454,9 @@ packages:
   '@emnapi/runtime@1.11.1':
     resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
 
+  '@emnapi/runtime@1.11.2':
+    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
+
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
@@ -830,6 +836,37 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@kreuzberg/node-darwin-arm64@4.10.2':
+    resolution: {integrity: sha512-XXOoXVYvPAvp8rGQPRpIdKZr4kqPgLG8qp+LdTmjun82AMz11KqAb0HHHuA5kDQ6OiVnM78rvDRYHN36FsprMQ==}
+    engines: {bun: '>= 1.3', node: '>= 22'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@kreuzberg/node-linux-arm64-gnu@4.10.2':
+    resolution: {integrity: sha512-vGbBOPo0yy2b1qhffeyGhi+gZVfmHTcq3Rqz0sHnA/kz9JB1T//4gB9QjCHA/6fPdXV6hjHvFLk6lftLzpoi7A==}
+    engines: {bun: '>= 1.3', node: '>= 22'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@kreuzberg/node-linux-x64-gnu@4.10.2':
+    resolution: {integrity: sha512-qA9kfoYTP3sShMnoJTKAv0k/Acj174cIeXPvBkF/QZL+2k7Zqy+iAUaACflJJb2hlsvyO7qPo/K5La+GrUSYRA==}
+    engines: {bun: '>= 1.3', node: '>= 22'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@kreuzberg/node-win32-x64-msvc@4.10.2':
+    resolution: {integrity: sha512-CQywJ5hZwihdJ0gpSY/k+njtSdmD3tAg+vU+1uHhrmmRArKlxwuqeqMqfKwMbrDwPvMgWkf3QjAFe27CZ3xL5w==}
+    engines: {bun: '>= 1.3', node: '>= 22'}
+    cpu: [x64]
+    os: [win32]
+
+  '@kreuzberg/node@4.10.2':
+    resolution: {integrity: sha512-cOp4SpS4/dZ2MX4jJT8vvcb4KF6eM68JJPPs2ykUnH3+ypvdkJlZC92GOylczw0TNa3yiXB7EGBMrbicHCLbHw==}
+    engines: {bun: '>= 1.3', node: '>= 22'}
+    hasBin: true
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -1881,6 +1918,10 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  isexe@4.0.0:
+    resolution: {integrity: sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==}
+    engines: {node: '>=20'}
+
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
@@ -2724,6 +2765,11 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  which@7.0.0:
+    resolution: {integrity: sha512-RancgH2dmbLdHl6LRhEqvklWMgl/Hdnun0Y90KhBOLkMefg8Qa7/Zel8Sm+8HEcP6DEjzsWzpkuBQEZok58isA==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -3402,6 +3448,10 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/runtime@1.11.2':
+    dependencies:
+      tslib: 2.8.1
+
   '@emnapi/wasi-threads@1.2.2':
     dependencies:
       tslib: 2.8.1
@@ -3673,6 +3723,28 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@kreuzberg/node-darwin-arm64@4.10.2':
+    optional: true
+
+  '@kreuzberg/node-linux-arm64-gnu@4.10.2':
+    optional: true
+
+  '@kreuzberg/node-linux-x64-gnu@4.10.2':
+    optional: true
+
+  '@kreuzberg/node-win32-x64-msvc@4.10.2':
+    optional: true
+
+  '@kreuzberg/node@4.10.2':
+    dependencies:
+      '@emnapi/runtime': 1.11.2
+      which: 7.0.0
+    optionalDependencies:
+      '@kreuzberg/node-darwin-arm64': 4.10.2
+      '@kreuzberg/node-linux-arm64-gnu': 4.10.2
+      '@kreuzberg/node-linux-x64-gnu': 4.10.2
+      '@kreuzberg/node-win32-x64-msvc': 4.10.2
 
   '@manypkg/find-root@1.1.0':
     dependencies:
@@ -4703,6 +4775,8 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  isexe@4.0.0: {}
+
   istanbul-lib-coverage@3.2.2: {}
 
   istanbul-lib-report@3.0.1:
@@ -5471,6 +5545,10 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  which@7.0.0:
+    dependencies:
+      isexe: 4.0.0
 
   why-is-node-running@2.3.0:
     dependencies:

--- a/src/node/native-coexistence.spec.ts
+++ b/src/node/native-coexistence.spec.ts
@@ -52,13 +52,6 @@ async function exerciseNativeConsumer(entrypoint: string) {
       import { readFile } from 'node:fs/promises';
       import { pathToFileURL } from 'node:url';
 
-      const nativeAddons = [];
-      const originalDlopen = process.dlopen;
-      process.dlopen = function trackedDlopen(module, filename, flags) {
-        nativeAddons.push(String(filename));
-        return originalDlopen.call(this, module, filename, flags);
-      };
-
       const kreuzberg = await import('@kreuzberg/node');
       kreuzberg.listOcrBackends();
       await import('sharp');
@@ -67,7 +60,7 @@ async function exerciseNativeConsumer(entrypoint: string) {
       const { getAvailableProviders, getProviderInfo, OCRFactory } = await import(entrypoint);
       const providers = await getAvailableProviders();
       const onnxInfo = await getProviderInfo('onnx');
-      const discoveryAddons = [...nativeAddons];
+      const discoveryAddons = process.report.getReport().sharedObjects;
 
       const factory = new OCRFactory({ provider: 'onnx' });
       const image = await readFile(process.argv[2]);
@@ -76,29 +69,36 @@ async function exerciseNativeConsumer(entrypoint: string) {
 
       console.log(JSON.stringify({
         discoveryAddons,
-        nativeAddons,
+        nativeAddons: process.report.getReport().sharedObjects,
         ocrText: ocrResult.text,
         onnxInfo,
         providers,
       }));
     `;
-  const { stdout } = await execFileAsync(
-    process.execPath,
-    [
-      '--import',
-      'tsx',
-      '--input-type=module',
-      '--eval',
-      source,
-      entrypoint,
-      resolve('test/test.png'),
-    ],
-    {
-      cwd: process.cwd(),
-      maxBuffer: 1024 * 1024,
-      timeout: 120_000,
-    },
-  );
+  let stdout: string;
+  try {
+    ({ stdout } = await execFileAsync(
+      process.execPath,
+      [
+        '--import',
+        'tsx',
+        '--input-type=module',
+        '--eval',
+        source,
+        entrypoint,
+        resolve('test/test.png'),
+      ],
+      {
+        cwd: process.cwd(),
+        maxBuffer: 1024 * 1024,
+        timeout: 120_000,
+      },
+    ));
+  } catch {
+    throw new Error(
+      `Native consumer must support OCR discovery and execution on ${process.platform}-${process.arch}`,
+    );
+  }
   return JSON.parse(stdout.trim()) as {
     discoveryAddons: string[];
     nativeAddons: string[];
@@ -135,7 +135,7 @@ function assertNativeCoexistence(
 
 describe('native consumer coexistence', () => {
   test.skipIf(!kreuzbergAvailable)(
-    'keeps discovery isolated and performs OCR beside Kreuzberg and Sharp',
+    'keeps discovery isolated while preserving OCR functionality',
     async () => {
       assertNativeCoexistence(
         await exerciseNativeConsumer(resolve('src/index.ts')),

--- a/src/node/native-coexistence.spec.ts
+++ b/src/node/native-coexistence.spec.ts
@@ -1,0 +1,119 @@
+import { execFile } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { promisify } from 'node:util';
+import { describe, expect, test } from 'vitest';
+
+const execFileAsync = promisify(execFile);
+const kreuzbergSupported =
+  (process.platform === 'darwin' && process.arch === 'arm64') ||
+  (process.platform === 'win32' && process.arch === 'x64') ||
+  (process.platform === 'linux' &&
+    (process.arch === 'arm64' || process.arch === 'x64') &&
+    Boolean(process.report.getReport().header.glibcVersionRuntime));
+
+async function exerciseNativeConsumer(entrypoint: string) {
+  const source = `
+      import { readFile } from 'node:fs/promises';
+      import { pathToFileURL } from 'node:url';
+
+      const nativeAddons = [];
+      const originalDlopen = process.dlopen;
+      process.dlopen = function trackedDlopen(module, filename, flags) {
+        nativeAddons.push(String(filename));
+        return originalDlopen.call(this, module, filename, flags);
+      };
+
+      const kreuzberg = await import('@kreuzberg/node');
+      kreuzberg.listOcrBackends();
+      await import('sharp');
+
+      const entrypoint = pathToFileURL(process.argv[1]).href;
+      const { getAvailableProviders, getProviderInfo, OCRFactory } = await import(entrypoint);
+      const providers = await getAvailableProviders();
+      const onnxInfo = await getProviderInfo('onnx');
+      const discoveryAddons = [...nativeAddons];
+
+      const factory = new OCRFactory({ provider: 'onnx' });
+      const image = await readFile(process.argv[2]);
+      const ocrResult = await factory.performOCR([{ data: image }]);
+      await factory.cleanup();
+
+      console.log(JSON.stringify({
+        discoveryAddons,
+        nativeAddons,
+        ocrText: ocrResult.text,
+        onnxInfo,
+        providers,
+      }));
+    `;
+  const { stdout } = await execFileAsync(
+    process.execPath,
+    [
+      '--import',
+      'tsx',
+      '--input-type=module',
+      '--eval',
+      source,
+      entrypoint,
+      resolve('test/test.png'),
+    ],
+    {
+      cwd: process.cwd(),
+      maxBuffer: 1024 * 1024,
+      timeout: 120_000,
+    },
+  );
+  return JSON.parse(stdout.trim()) as {
+    discoveryAddons: string[];
+    nativeAddons: string[];
+    ocrText: string;
+    onnxInfo: { available: boolean } | null;
+    providers: string[];
+  };
+}
+
+function assertNativeCoexistence(
+  result: Awaited<ReturnType<typeof exerciseNativeConsumer>>,
+) {
+  expect(result.providers).toContain('onnx');
+  expect(result.onnxInfo?.available).toBe(true);
+  expect(result.ocrText.trim().length).toBeGreaterThan(0);
+
+  expect(
+    result.discoveryAddons.some((filename) => filename.includes('kreuzberg')),
+  ).toBe(true);
+  expect(
+    result.discoveryAddons.some((filename) => filename.includes('sharp')),
+  ).toBe(true);
+  expect(
+    result.discoveryAddons.some((filename) =>
+      filename.includes('onnxruntime_binding'),
+    ),
+  ).toBe(false);
+  expect(
+    result.nativeAddons.some((filename) =>
+      filename.includes('onnxruntime_binding'),
+    ),
+  ).toBe(true);
+}
+
+describe('native consumer coexistence', () => {
+  test.skipIf(!kreuzbergSupported)(
+    'keeps discovery isolated and performs OCR beside Kreuzberg and Sharp',
+    async () => {
+      assertNativeCoexistence(
+        await exerciseNativeConsumer(resolve('src/index.ts')),
+      );
+    },
+  );
+
+  test.skipIf(!kreuzbergSupported || !existsSync(resolve('dist/index.js')))(
+    'preserves native coexistence in the built package',
+    async () => {
+      assertNativeCoexistence(
+        await exerciseNativeConsumer(resolve('dist/index.js')),
+      );
+    },
+  );
+});

--- a/src/node/native-coexistence.spec.ts
+++ b/src/node/native-coexistence.spec.ts
@@ -5,12 +5,47 @@ import { promisify } from 'node:util';
 import { describe, expect, test } from 'vitest';
 
 const execFileAsync = promisify(execFile);
-const kreuzbergSupported =
+const glibcVersion =
+  process.platform === 'linux'
+    ? process.report.getReport().header.glibcVersionRuntime
+    : undefined;
+const [glibcMajor = 0, glibcMinor = 0] = (glibcVersion ?? '')
+  .split('.')
+  .map(Number);
+const declaredKreuzbergTuple =
   (process.platform === 'darwin' && process.arch === 'arm64') ||
   (process.platform === 'win32' && process.arch === 'x64') ||
   (process.platform === 'linux' &&
     (process.arch === 'arm64' || process.arch === 'x64') &&
-    Boolean(process.report.getReport().header.glibcVersionRuntime));
+    Boolean(glibcVersion));
+const incompatibleLinuxABI =
+  process.platform === 'linux' &&
+  Boolean(glibcVersion) &&
+  (glibcMajor < 2 || (glibcMajor === 2 && glibcMinor < 39));
+
+async function canLoadKreuzberg(): Promise<boolean> {
+  try {
+    await execFileAsync(
+      process.execPath,
+      [
+        '--input-type=module',
+        '--eval',
+        "const kreuzberg = await import('@kreuzberg/node'); kreuzberg.listOcrBackends();",
+      ],
+      { cwd: process.cwd(), timeout: 30_000 },
+    );
+    return true;
+  } catch {
+    if (declaredKreuzbergTuple && !incompatibleLinuxABI) {
+      throw new Error(
+        `Kreuzberg native bindings must load on ${process.platform}-${process.arch}`,
+      );
+    }
+    return false;
+  }
+}
+
+const kreuzbergAvailable = await canLoadKreuzberg();
 
 async function exerciseNativeConsumer(entrypoint: string) {
   const source = `
@@ -99,7 +134,7 @@ function assertNativeCoexistence(
 }
 
 describe('native consumer coexistence', () => {
-  test.skipIf(!kreuzbergSupported)(
+  test.skipIf(!kreuzbergAvailable)(
     'keeps discovery isolated and performs OCR beside Kreuzberg and Sharp',
     async () => {
       assertNativeCoexistence(
@@ -108,7 +143,7 @@ describe('native consumer coexistence', () => {
     },
   );
 
-  test.skipIf(!kreuzbergSupported || !existsSync(resolve('dist/index.js')))(
+  test.skipIf(!kreuzbergAvailable || !existsSync(resolve('dist/index.js')))(
     'preserves native coexistence in the built package',
     async () => {
       assertNativeCoexistence(

--- a/src/node/onnx-gutenye.ts
+++ b/src/node/onnx-gutenye.ts
@@ -3,6 +3,8 @@
  * package-owned Sharp and ONNX Runtime backend.
  */
 
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import type {
   DependencyCheckResult,
   OCRCapabilities,
@@ -12,13 +14,108 @@ import type {
   OCRResult,
 } from '../shared/types';
 import { OCRDependencyError } from '../shared/types';
-import {
-  createGutenyeOCR,
-  type GutenyeDetection,
-  type GutenyeImageInput,
-  type GutenyeOCR,
-  nativeDependencyVersions,
+import type {
+  GutenyeDetection,
+  GutenyeImageInput,
+  GutenyeOCR,
 } from './gutenye-runtime';
+
+type NativeRuntime = typeof import('./gutenye-runtime');
+
+const execFileAsync = promisify(execFile);
+const nativeDependencyNames = ['sharp', 'onnxruntime-node'] as const;
+
+let nativeRuntimePromise: Promise<NativeRuntime> | null = null;
+let nativeDependencyCheckPromise: Promise<DependencyCheckResult> | null = null;
+
+function loadNativeRuntime(): Promise<NativeRuntime> {
+  if (!nativeRuntimePromise) {
+    nativeRuntimePromise = import('./gutenye-runtime.js');
+  }
+  return nativeRuntimePromise;
+}
+
+async function checkNativeDependencies(): Promise<DependencyCheckResult> {
+  const details: Record<string, boolean> = {
+    sharp: false,
+    'onnxruntime-node': false,
+    'gutenye-ocr-common': true,
+  };
+  const resolvedDependencies: Array<[string, string]> = [];
+
+  for (const name of nativeDependencyNames) {
+    try {
+      resolvedDependencies.push([name, import.meta.resolve(name)]);
+    } catch {
+      details[name] = false;
+    }
+  }
+
+  if (resolvedDependencies.length !== nativeDependencyNames.length) {
+    return {
+      available: false,
+      details,
+      error: 'Native PaddleOCR dependencies are not installed',
+    };
+  }
+
+  const validationScript = `
+    const dependencies = JSON.parse(process.argv[1]);
+    const results = {};
+    for (const [name, url] of dependencies) {
+      try {
+        const loaded = await import(url);
+        const version = name === 'sharp'
+          ? loaded.default?.versions?.sharp
+          : loaded.env?.versions?.node;
+        results[name] = { available: true, version };
+      } catch {
+        results[name] = { available: false };
+      }
+    }
+    process.stdout.write(JSON.stringify(results));
+  `;
+
+  const versions: Record<string, string | undefined> = {};
+  try {
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      [
+        '--input-type=module',
+        '--eval',
+        validationScript,
+        JSON.stringify(resolvedDependencies),
+      ],
+      { timeout: 30_000, windowsHide: true },
+    );
+    const results = JSON.parse(stdout) as Record<
+      string,
+      { available: boolean; version?: string }
+    >;
+    for (const name of nativeDependencyNames) {
+      details[name] = results[name]?.available ?? false;
+      versions[name] = results[name]?.version;
+    }
+  } catch {
+    return {
+      available: false,
+      details,
+      error: 'Native PaddleOCR dependencies failed to load',
+    };
+  }
+
+  const available = nativeDependencyNames.every((name) => details[name]);
+  return {
+    available,
+    details,
+    error: available
+      ? undefined
+      : 'Native PaddleOCR dependencies failed to load',
+    version: available
+      ? `Sharp ${versions.sharp}, ONNX Runtime ${versions['onnxruntime-node']}`
+      : undefined,
+  };
+}
 
 /** ONNX PaddleOCR provider backed by Sharp and ONNX Runtime on Node.js. */
 export class ONNXGutenyeProvider implements OCRProvider {
@@ -34,7 +131,8 @@ export class ONNXGutenyeProvider implements OCRProvider {
     if (this.initialized) return;
 
     if (!this.initializationPromise) {
-      const initialization = createGutenyeOCR()
+      const initialization = loadNativeRuntime()
+        .then(({ createGutenyeOCR }) => createGutenyeOCR())
         .then((ocr) => {
           this.ocrInstance = ocr;
           this.initialized = true;
@@ -161,17 +259,11 @@ export class ONNXGutenyeProvider implements OCRProvider {
   }
 
   async checkDependencies(): Promise<DependencyCheckResult> {
-    return {
-      available: Boolean(
-        nativeDependencyVersions.sharp && nativeDependencyVersions.onnxRuntime,
-      ),
-      details: {
-        sharp: Boolean(nativeDependencyVersions.sharp),
-        'onnxruntime-node': Boolean(nativeDependencyVersions.onnxRuntime),
-        'gutenye-ocr-common': true,
-      },
-      version: `Sharp ${nativeDependencyVersions.sharp}, ONNX Runtime ${nativeDependencyVersions.onnxRuntime}`,
-    };
+    if (!nativeDependencyCheckPromise) {
+      nativeDependencyCheckPromise = checkNativeDependencies();
+    }
+    const result = await nativeDependencyCheckPromise;
+    return { ...result, details: { ...result.details } };
   }
 
   async checkCapabilities(): Promise<OCRCapabilities> {

--- a/src/node/onnx-gutenye.ts
+++ b/src/node/onnx-gutenye.ts
@@ -23,7 +23,13 @@ import type {
 type NativeRuntime = typeof import('./gutenye-runtime');
 
 const execFileAsync = promisify(execFile);
-const nativeDependencyNames = ['sharp', 'onnxruntime-node'] as const;
+const runtimeDependencies = [
+  ['sharp', 'sharp'],
+  ['onnxruntime-node', 'onnxruntime-node'],
+  ['gutenye-ocr-common', '@gutenye/ocr-common'],
+  ['gutenye-split-into-line-images', '@gutenye/ocr-common/splitIntoLineImages'],
+  ['gutenye-ocr-models', '@gutenye/ocr-models/node'],
+] as const;
 
 let nativeRuntimePromise: Promise<NativeRuntime> | null = null;
 let nativeDependencyCheckPromise: Promise<DependencyCheckResult> | null = null;
@@ -36,22 +42,19 @@ function loadNativeRuntime(): Promise<NativeRuntime> {
 }
 
 async function checkNativeDependencies(): Promise<DependencyCheckResult> {
-  const details: Record<string, boolean> = {
-    sharp: false,
-    'onnxruntime-node': false,
-    'gutenye-ocr-common': true,
-  };
+  const details: Record<string, boolean> = {};
   const resolvedDependencies: Array<[string, string]> = [];
 
-  for (const name of nativeDependencyNames) {
+  for (const [name, specifier] of runtimeDependencies) {
+    details[name] = false;
     try {
-      resolvedDependencies.push([name, import.meta.resolve(name)]);
+      resolvedDependencies.push([name, import.meta.resolve(specifier)]);
     } catch {
       details[name] = false;
     }
   }
 
-  if (resolvedDependencies.length !== nativeDependencyNames.length) {
+  if (resolvedDependencies.length !== runtimeDependencies.length) {
     return {
       available: false,
       details,
@@ -60,11 +63,52 @@ async function checkNativeDependencies(): Promise<DependencyCheckResult> {
   }
 
   const validationScript = `
+    const { constants } = await import('node:fs');
+    const { access, stat } = await import('node:fs/promises');
+    const { dirname, resolve } = await import('node:path');
+    const { fileURLToPath } = await import('node:url');
     const dependencies = JSON.parse(process.argv[1]);
     const results = {};
     for (const [name, url] of dependencies) {
       try {
         const loaded = await import(url);
+        if (name === 'gutenye-ocr-common') {
+          if (
+            typeof loaded.default?.create !== 'function' ||
+            typeof loaded.FileUtilsBase !== 'function' ||
+            typeof loaded.ImageRawBase !== 'function' ||
+            typeof loaded.registerBackend !== 'function'
+          ) throw new Error('Gutenye common exports are incomplete');
+        }
+        if (
+          name === 'gutenye-split-into-line-images' &&
+          typeof loaded.splitIntoLineImages !== 'function'
+        ) throw new Error('Gutenye line splitting export is unavailable');
+        if (name === 'gutenye-ocr-models') {
+          const paths = loaded.default;
+          if (
+            typeof paths?.detectionPath !== 'string' ||
+            typeof paths?.recognitionPath !== 'string' ||
+            typeof paths?.dictionaryPath !== 'string'
+          ) throw new Error('Gutenye model exports are incomplete');
+          const modelsDirectory = dirname(fileURLToPath(url));
+          const runtimePaths = [
+            resolve(modelsDirectory, 'assets/ch_PP-OCRv4_det_infer.onnx'),
+            resolve(modelsDirectory, 'assets/ch_PP-OCRv4_rec_infer.onnx'),
+            resolve(modelsDirectory, 'assets/ppocr_keys_v1.txt'),
+          ];
+          for (const path of [
+            paths.detectionPath,
+            paths.recognitionPath,
+            paths.dictionaryPath,
+            ...runtimePaths,
+          ]) {
+            await access(path, constants.R_OK);
+            if (!(await stat(path)).isFile()) {
+              throw new Error('Gutenye model asset is not a regular file');
+            }
+          }
+        }
         const version = name === 'sharp'
           ? loaded.default?.versions?.sharp
           : loaded.env?.versions?.node;
@@ -92,7 +136,7 @@ async function checkNativeDependencies(): Promise<DependencyCheckResult> {
       string,
       { available: boolean; version?: string }
     >;
-    for (const name of nativeDependencyNames) {
+    for (const [name] of runtimeDependencies) {
       details[name] = results[name]?.available ?? false;
       versions[name] = results[name]?.version;
     }
@@ -104,7 +148,7 @@ async function checkNativeDependencies(): Promise<DependencyCheckResult> {
     };
   }
 
-  const available = nativeDependencyNames.every((name) => details[name]);
+  const available = runtimeDependencies.every(([name]) => details[name]);
   return {
     available,
     details,

--- a/src/node/providers.spec.ts
+++ b/src/node/providers.spec.ts
@@ -139,6 +139,19 @@ describe('ONNXGutenyeProvider', () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
   });
 
+  test('validates every native and Gutenye runtime dependency', async () => {
+    const dependencies = await new ONNXGutenyeProvider().checkDependencies();
+
+    expect(dependencies.available).toBe(true);
+    expect(dependencies.details).toEqual({
+      sharp: true,
+      'onnxruntime-node': true,
+      'gutenye-ocr-common': true,
+      'gutenye-split-into-line-images': true,
+      'gutenye-ocr-models': true,
+    });
+  });
+
   test('processes raw RGB data and filters detections by confidence', async () => {
     const detect = vi.fn().mockResolvedValue([
       {


### PR DESCRIPTION
## Summary

- defer loading OCR's Sharp and ONNX Runtime addons until the ONNX provider performs its first OCR operation
- preserve accurate dependency readiness by probing the native addons in an isolated, memoized child process
- add source and built-package consumer regressions that discover, validate, and perform real ONNX OCR alongside Kreuzberg and Sharp
- document the native loading lifecycle and add a patch changeset

This fixes the upstream native-runtime blocker reported by [anytown/anytown.ai#716](https://github.com/anytown/anytown.ai/issues/716). The Anytown consumer performs no OCR in the failing path; OCR 0.61.1 was loading its native stack during provider checks inside the Vitest worker, alongside Kreuzberg, Sharp, and another ONNX Runtime version.

## Validation

- `pnpm deps:check` — SDK 0.80.0, one Sharp 0.35.3 installation
- `pnpm lint`, `pnpm typecheck`, `pnpm build`, `pnpm docs:api:check`
- `pnpm test:coverage` — 112 passed; 81.64% statements, 70.47% branches, 88.73% functions, 82.85% lines
- source and built consumer regression — provider dependency check and real ONNX OCR pass beside Kreuzberg 4.10.2 and Sharp
- packed final build in the exact Anytown worktree — Meeting 65/65; full Praeco 696 passed, 42 skipped
- two-reviewer final review cycle — clean

Closes #116

Do not merge without human review.

<!-- hv-agent-run:v1 -->
{
  "schema": "hv-agent-run:v1",
  "runtime": "codex",
  "session": "019f6e77-7deb-7ec1-9c3d-3559a2f719f3",
  "issue": "happyvertical/ocr#116",
  "policy_revision": "1.0.0",
  "validation": [
    "pnpm deps:check: one Sharp 0.35.3 and SDK 0.80.0",
    "pnpm test:coverage: 112 passed; 81.64/70.47/88.73/82.85",
    "pnpm build, typecheck, lint, docs:api:check: passed",
    "source and built Kreuzberg/Sharp/ONNX coexistence regression: passed",
    "packed Anytown Meeting 65/65 and full Praeco 696 passed: passed",
    "review-cycle final roster: clean"
  ]
}
