### PR TITLE
chore: migrate agent workflows to the generation-3 split layout

### DIFF
--- a/.agents/project.yaml
+++ b/.agents/project.yaml
@@ -46,6 +46,7 @@
     ]
   },
   "runtime": {
-    "agent_policy_workflow": ".github/workflows/on-pull-request.yml"
+    "agent_validation_workflow": ".github/workflows/on-pull-request.yml",
+    "agent_lifecycle_stage": "compatibility"
   }
 }

--- a/.github/workflows/agent-policy.yml
+++ b/.github/workflows/agent-policy.yml
@@ -1,0 +1,67 @@
+name: Agent Policy
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review, converted_to_draft, labeled, unlabeled]
+  merge_group:
+    types: [checks_requested]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to recheck after a claim-only transition
+        required: true
+        type: number
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+  packages: read
+
+jobs:
+  lifecycle:
+    name: lifecycle
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1
+      - name: Load pinned policy runtime
+        env:
+          POLICY_ARTIFACT: ${{ vars.AGENT_POLICY_ARTIFACT }}
+        run: |
+          case "$POLICY_ARTIFACT" in
+            ghcr.io/*@sha256:*) ;;
+            *) echo 'AGENT_POLICY_ARTIFACT must be an immutable GHCR digest' >&2; exit 1 ;;
+          esac
+          policy_dir="$RUNNER_TEMP/hv-policy"
+          rm -rf "$policy_dir"
+          mkdir -p "$policy_dir"
+          oras pull "$POLICY_ARTIFACT" -o "$policy_dir"
+          archive="$policy_dir/agent-policy.tar.gz"
+          test -f "$archive" || { echo 'policy artifact is missing agent-policy.tar.gz' >&2; exit 1; }
+          python3 - "$archive" <<'PY'
+          import pathlib
+          import sys
+          import tarfile
+
+          with tarfile.open(sys.argv[1], "r:gz") as archive:
+              for member in archive.getmembers():
+                  path = pathlib.PurePosixPath(member.name)
+                  if path.is_absolute() or ".." in path.parts or member.issym() or member.islnk():
+                      raise SystemExit(f"unsafe policy archive member: {member.name}")
+          PY
+          tar -xzf "$archive" -C "$policy_dir"
+          echo "HV_POLICY_DIR=$policy_dir" >> "$GITHUB_ENV"
+      - name: Validate lifecycle
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
+          MERGE_GROUP_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
+          MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref }}
+        run: |
+          "$HV_POLICY_DIR/scripts/hv-agent-lifecycle-prs" | while IFS= read -r number; do
+            python3 "$HV_POLICY_DIR/scripts/hv-agent" check-pr "$number"
+          done

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -3,21 +3,13 @@ name: Pull Request Validation
 on:
   pull_request:
     branches: [main]
-    types: [opened, edited, synchronize, reopened, ready_for_review, converted_to_draft, labeled, unlabeled]
+    types: [opened, synchronize, reopened]
   merge_group:
     types: [checks_requested]
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: Pull request number to recheck after a claim-only transition
-        required: true
-        type: number
-
 concurrency:
   group: >-
     ${{ github.workflow }}-${{
       github.event.pull_request.number ||
-      inputs.pr_number ||
       github.event.merge_group.head_sha ||
       github.ref
     }}-${{
@@ -40,74 +32,13 @@ permissions:
   pull-requests: write
 
 jobs:
-  # hv-agent-policy:start
-  lifecycle:
-    name: lifecycle
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'pull_request' ||
-      github.event_name == 'merge_group'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: read
-      issues: read
-      pull-requests: read
-      packages: read
-    steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-      - uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1
-      - name: Load pinned policy runtime
-        env:
-          POLICY_ARTIFACT: ${{ vars.AGENT_POLICY_ARTIFACT }}
-        run: |
-          case "$POLICY_ARTIFACT" in
-            ghcr.io/*@sha256:*) ;;
-            *) echo 'AGENT_POLICY_ARTIFACT must be an immutable GHCR digest' >&2; exit 1 ;;
-          esac
-          policy_dir="$RUNNER_TEMP/hv-policy"
-          rm -rf "$policy_dir"
-          mkdir -p "$policy_dir"
-          oras pull "$POLICY_ARTIFACT" -o "$policy_dir"
-          archive="$policy_dir/agent-policy.tar.gz"
-          test -f "$archive" || { echo 'policy artifact is missing agent-policy.tar.gz' >&2; exit 1; }
-          python3 - "$archive" <<'PY'
-          import pathlib
-          import sys
-          import tarfile
-
-          with tarfile.open(sys.argv[1], "r:gz") as archive:
-              for member in archive.getmembers():
-                  path = pathlib.PurePosixPath(member.name)
-                  if path.is_absolute() or ".." in path.parts or member.issym() or member.islnk():
-                      raise SystemExit(f"unsafe policy archive member: {member.name}")
-          PY
-          tar -xzf "$archive" -C "$policy_dir"
-          echo "HV_POLICY_DIR=$policy_dir" >> "$GITHUB_ENV"
-      - name: Validate lifecycle
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-          EVENT_NAME: ${{ github.event_name }}
-          PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
-          MERGE_GROUP_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
-          MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref }}
-        run: |
-          set -euo pipefail
-          numbers_file="$RUNNER_TEMP/hv-agent-lifecycle-prs"
-          "$HV_POLICY_DIR/scripts/hv-agent-lifecycle-prs" > "$numbers_file"
-          while IFS= read -r number; do
-            python3 "$HV_POLICY_DIR/scripts/hv-agent" check-pr "$number"
-          done < "$numbers_file"
-  # hv-agent-policy:end
 
   validate-commits:
     name: Validate Conventional Commits
     if: >-
-      github.event_name == 'pull_request' &&
-      (contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) ||
-      (github.event.action == 'edited' &&
-      (github.event.changes.base != null || github.event.changes.title != null)))
+      github.event_name == 'merge_group' ||
+      (github.event_name == 'pull_request' &&
+      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
     runs-on: arc-happyvertical
 
     steps:
@@ -191,150 +122,28 @@ jobs:
     if: >-
       github.event_name == 'merge_group' ||
       (github.event_name == 'pull_request' &&
-      (contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) ||
-      (github.event.action == 'edited' && github.event.changes.base != null)))
+      contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action))
     uses: ./.github/workflows/test.yml
     secrets:
       HAVE_RELEASE_APP_ID: ${{ secrets.HAVE_RELEASE_APP_ID }}
       HAVE_RELEASE_APP_PRIVATE_KEY: ${{ secrets.HAVE_RELEASE_APP_PRIVATE_KEY }}
 
-  validation-gate:
-    name: >-
-      Required CI / ${{ (github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && !contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) && !(github.event.action == 'edited' && github.event.changes.base != null))) && 'inactive validation' || 'validation' }}
-    if: >-
-      always() &&
-      (github.event_name == 'merge_group' ||
-      (github.event_name == 'pull_request' &&
-      (contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) ||
-      (github.event.action == 'edited' && github.event.changes.base != null))))
-    needs: [lifecycle, validate-commits, test]
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      checks: read
-      contents: read
-      pull-requests: read
-    steps:
-      - name: Verify or preserve required validation
-        env:
-          GH_TOKEN: ${{ github.token }}
-          EVENT_NAME: ${{ github.event_name }}
-          EVENT_ACTION: ${{ github.event.action }}
-          BASE_CHANGED: ${{ github.event.changes.base != null }}
-          TITLE_CHANGED: ${{ github.event.changes.title != null }}
-          PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
-          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
-          LIFECYCLE: ${{ needs.lifecycle.result }}
-          COMMITS: ${{ needs.validate-commits.result }}
-          TEST: ${{ needs.test.result }}
-        run: |
-          set -euo pipefail
-          require_success() {
-            if [ "$2" != success ]; then
-              echo "::error::$1 must succeed, got: $2"
-              exit 1
-            fi
-          }
-
-          require_success 'Lifecycle policy' "$LIFECYCLE"
-          require_success 'Tests' "$TEST"
-          if [ "$EVENT_NAME" = pull_request ]; then
-            require_success 'Conventional commits' "$COMMITS"
-          elif [ "$COMMITS" != skipped ]; then
-            echo "::error::Conventional commits should be skipped for $EVENT_NAME, got: $COMMITS"
-            exit 1
-          fi
-          echo "Validation baseline passed for $EVENT_NAME"
-
-  metadata-gate:
-    name: Required CI / metadata
-    if: >-
-      always() &&
-      (github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' &&
-      !contains(fromJSON('["opened","synchronize","reopened"]'), github.event.action) &&
-      !(github.event.action == 'edited' && github.event.changes.base != null)))
-    needs: [lifecycle, validate-commits]
-    outputs:
-      prerequisites-passed: ${{ steps.prerequisites.outputs.passed }}
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      checks: read
-      contents: read
-      pull-requests: read
-    steps:
-      - name: Validate metadata prerequisites
-        id: prerequisites
-        env:
-          EVENT_ACTION: ${{ github.event.action }}
-          TITLE_CHANGED: ${{ github.event.changes.title != null }}
-          LIFECYCLE: ${{ needs.lifecycle.result }}
-          COMMITS: ${{ needs.validate-commits.result }}
-        run: |
-          set -euo pipefail
-          [ "$LIFECYCLE" = success ] || { echo "::error::Lifecycle policy failed: $LIFECYCLE"; exit 1; }
-          if [ "$EVENT_ACTION" = edited ] && [ "$TITLE_CHANGED" = true ] && [ "$COMMITS" != success ]; then
-            echo "::error::Conventional title validation failed: $COMMITS"
-            exit 1
-          fi
-          echo "passed=true" >> "$GITHUB_OUTPUT"
-      - name: Preserve validation baseline
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
-          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-        run: |
-          set -euo pipefail
-          head_sha="$EVENT_HEAD_SHA"
-          if [ "${{ github.event_name }}" = workflow_dispatch ]; then
-            head_sha=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq .head.sha)
-          fi
-          checks=$(gh api "repos/$GITHUB_REPOSITORY/commits/$head_sha/check-runs?check_name=Required%20CI%20%2F%20validation&filter=all&per_page=100")
-          pending=$(printf '%s\n' "$checks" | jq --arg current_run "/actions/runs/$GITHUB_RUN_ID/" '[.check_runs[] | select(.name == "Required CI / validation" and .status != "completed") | select(((.details_url // "") | contains($current_run)) | not)] | length')
-          latest=$(printf '%s\n' "$checks" | jq -r '[.check_runs[] | select(.name == "Required CI / validation" and .status == "completed" and .conclusion != "skipped")] | sort_by(.completed_at) | reverse | .[0].conclusion // "missing"')
-          if [ "$pending" -gt 0 ] || [ "$latest" != success ]; then
-            echo "::error::Validation baseline for $head_sha is pending=$pending latest=$latest"
-            exit 1
-          fi
-
   required-ci:
     name: Required CI
     if: always()
-    needs: [validation-gate, metadata-gate]
+    needs: [validate-commits, test]
     runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      checks: read
-      contents: read
-      pull-requests: read
+    timeout-minutes: 5
     steps:
-      - name: Require the event-appropriate gate
+      - name: Require full validation success
         env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
-          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-          VALIDATION: ${{ needs.validation-gate.result }}
-          METADATA: ${{ needs.metadata-gate.result }}
-          METADATA_PREREQUISITES: ${{ needs.metadata-gate.outputs.prerequisites-passed }}
+          VALIDATE_COMMITS: ${{ needs.validate-commits.result }}
+          TEST: ${{ needs.test.result }}
         run: |
           set -euo pipefail
-          if [ "$VALIDATION" = success ] && [ "$METADATA" = skipped ]; then
-            exit 0
-          fi
-          if [ "$VALIDATION" = skipped ] && [ "$METADATA_PREREQUISITES" = true ]; then
-            head_sha="$EVENT_HEAD_SHA"
-            if [ "${{ github.event_name }}" = workflow_dispatch ]; then
-              head_sha=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq .head.sha)
+          for result in "$VALIDATE_COMMITS" "$TEST"; do
+            if [ "$result" != success ]; then
+              echo "::error::full validation did not succeed: validate-commits=$VALIDATE_COMMITS test=$TEST"
+              exit 1
             fi
-            checks=$(gh api "repos/$GITHUB_REPOSITORY/commits/$head_sha/check-runs?check_name=Required%20CI%20%2F%20validation&filter=all&per_page=100")
-            pending=$(printf '%s\n' "$checks" | jq --arg current_run "/actions/runs/$GITHUB_RUN_ID/" '[.check_runs[] | select(.name == "Required CI / validation" and .status != "completed") | select(((.details_url // "") | contains($current_run)) | not)] | length')
-            latest=$(printf '%s\n' "$checks" | jq -r '[.check_runs[] | select(.name == "Required CI / validation" and .status == "completed" and .conclusion != "skipped")] | sort_by(.completed_at) | reverse | .[0].conclusion // "missing"')
-            if [ "$pending" -eq 0 ] && [ "$latest" = success ]; then
-              exit 0
-            fi
-            echo "::error::Final validation baseline for $head_sha is pending=$pending latest=$latest"
-            exit 1
-          fi
-          echo "::error::Expected exactly one valid gate; validation=$VALIDATION metadata=$METADATA metadata_prerequisites=$METADATA_PREREQUISITES"
-          exit 1
+          done


### PR DESCRIPTION
Migrates this repository to the split agent-policy layout (generation-3 migrator, [have-config@2f0d526a](https://github.com/happyvertical/have-config/commit/2f0d526a331c5b9f3c0e45130a5e3af22712b39b), tag `agent-policy-v1.0.10`): dedicated byte-canonical `agent-policy.yml`, validation isolated to code events, superseded validation-gate/metadata-gate meta-jobs removed, `Required CI` kept as its exact required context via a plain rollup, canonical full-validation gates, and retired-dispatch `PR_NUMBER` fallbacks dropped. Kernel block preserved so this stays green under the v1.0.9 pin (repointed ahead of this PR); the pin advances to generation 3 after this lands. Context: [have-config#180](https://github.com/happyvertical/have-config/issues/180).